### PR TITLE
Fix flavour fields

### DIFF
--- a/src/Matter.jl
+++ b/src/Matter.jl
@@ -105,7 +105,8 @@ function oscprob(U, H, energy::Vector{T}, path::Vector{Path}; zoa=0.5, anti=fals
         end
     end
     P = map(x -> abs.(x) .^ 2, A)
-    AxisArray(P; Energy=energy, Path=path, InitFlav=NeutrinoFlavour.(1:3), FinalFlav=NeutrinoFlavour.(1:3))
+    flavrange = _make_flavour_range(first(size(U)))
+    AxisArray(P; Energy=energy, Path=path, InitFlav=flavrange, FinalFlav=flavrange)
 end
 
 const oscprob(U, H, energy::T, path::Vector{Path}; zoa=0.5, anti=false) where {T <: Real} = oscprob(U, H, [energy], path; zoa=zoa, anti=anti)

--- a/src/Oscillation.jl
+++ b/src/Oscillation.jl
@@ -271,6 +271,15 @@ function _oscprobampl(U, H, energy, baseline)
     U * exp(-1im * H_diag) * adjoint(U)
 end
 
+function _make_flavour_range(size::Integer)
+    if size <= 3
+        return NeutrinoFlavour.(1:size)
+    else
+        return [NeutrinoFlavour.(1:3)..., 4:size...]
+    end
+end
+
+
 """
 $(SIGNATURES)
 
@@ -289,7 +298,8 @@ function oscprob(U, H, energy::Vector{T}, baseline::Vector{S}) where {T,S <: Rea
     tmp = map(x->abs.(_oscprobampl(U, H, first(x), last(x))).^2, combinations)
     P = reshape(hcat(collect(Iterators.flatten(tmp))), s...)
     P = permutedims(P, (3,4,1,2))
-    AxisArray(P; Energy=energy, Baseline=baseline, InitFlav=NeutrinoFlavour.(1:3), FinalFlav=NeutrinoFlavour.(1:3))
+    flavrange = _make_flavour_range(first(size(U)))
+    AxisArray(P; Energy=energy, Baseline=baseline, InitFlav=flavrange, FinalFlav=flavrange)
 end
 
 const oscprob(U, H, energy::T, baseline::Vector{S}) where {S,T <: Real} = oscprob(U, H, [energy], baseline)

--- a/test/oscillation_tests.jl
+++ b/test/oscillation_tests.jl
@@ -51,6 +51,12 @@ for i in 3:100
     end
 end
 
+osc = OscillationParameters(2)
+mixingangle!(osc, 1=>2, 0.59)
+masssquareddiff!(osc, 1=>2,-7.39e-5)
+test_values = Neurthino.oscprob(osc, 1, 10000)[Energy=1, Baseline=1]
+@test test_values[1,1] ≈ 0.4454 atol=0.01
+
 osc = OscillationParameters(4)
 mixingangle!(osc, 1=>2, 0.59)
 mixingangle!(osc, 1=>3, 0.15)

--- a/test/oscillation_tests.jl
+++ b/test/oscillation_tests.jl
@@ -51,6 +51,20 @@ for i in 3:100
     end
 end
 
+osc = OscillationParameters(4)
+mixingangle!(osc, 1=>2, 0.59)
+mixingangle!(osc, 1=>3, 0.15)
+mixingangle!(osc, 2=>3, 0.84)
+mixingangle!(osc, 1=>4, 0.2)
+mixingangle!(osc, 2=>4, 0.3)
+mixingangle!(osc, 3=>4, 0.4)
+masssquareddiff!(osc, 2=>3, -2.523e-3)
+masssquareddiff!(osc, 1=>2,-7.39e-5)
+masssquareddiff!(osc, 3=>4, -1)
+
+test_values = Neurthino.oscprob(osc, 1, 10000)[Energy=1, Baseline=1]
+@test test_values[1,1] ≈ 0.3373 atol=0.01
+
 h5open("data/refdata.h5", "r") do file
     # Nu-Fit v5.0 Values
     osc_nh = OscillationParameters(3);


### PR DESCRIPTION
The flavour fields in the returned `AxisArray` are accidentally fixed to 3, but the number can vary with respect to the chosen model.