### PR TITLE
Update dependency versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,10 +15,10 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 AxisArrays = "^0.4"
-DocStringExtensions = "^0.8"
+DocStringExtensions = "^0.9"
 LRUCache = "1"
 LightGraphs = "1"
-Polynomials = "1 - 3"
+Polynomials = "1, 2, 3"
 StaticArrays = "1"
 julia = "^1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -14,13 +14,13 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-AxisArrays = "0.4"
-DocStringExtensions = "0.8"
+AxisArrays = "^0.4"
+DocStringExtensions = "^0.8"
 LRUCache = "1"
 LightGraphs = "1"
-Polynomials = "1"
+Polynomials = "1 - 3"
 StaticArrays = "1"
-julia = "1.3"
+julia = "^1.3"
 
 [extras]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 AxisArrays = "^0.4"
-DocStringExtensions = "^0.9"
+DocStringExtensions = "0.8, 0.9"
 LRUCache = "1"
 LightGraphs = "1"
 Polynomials = "1, 2, 3"


### PR DESCRIPTION
The version dependencies seem to be a lil bit outdated, especially for `Polynomials` which is currently in major version 3. 